### PR TITLE
Adding missing namespace to profiler docs

### DIFF
--- a/doc/integrate.md
+++ b/doc/integrate.md
@@ -406,7 +406,7 @@ Add the following lines to the `Start()` function of a script that gets called w
 For example, you can add this to the Start() function in `ParamReader.cs`
 
 ```
-var profilingAreas = new UnityEngine.Profiling.ProfilerArea[] { ProfilerArea.CPU, ProfilerArea.GPU, ProfilerArea.Physics };
+var profilingAreas = new UnityEngine.Profiling.ProfilerArea[] { UnityEngine.Profiling.ProfilerArea.CPU, UnityEngine.Profiling.ProfilerArea.GPU, UnityEngine.Profiling.ProfilerArea.Physics };
 DXProfilerManager.EnableProfiling(profilingAreas);
 ```
 ![enable profiling](images/sdk8.png "Profiler")


### PR DESCRIPTION
`ProfilerArea` is missing its associated namespace. Either add a using declaration at the top of the file, or add the namespace inline.

