### PR TITLE
troubleshooting, quickstart: 0.8.2 cli updates

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -59,6 +59,8 @@ Windows:
 > cd C:\Users\MyName\Downloads\unity_simulation_bundle
 ```
 
+*NOTE*: macOS users may encounter issues with Gatekeeper; see the [troubleshooting guide](https://github.com/Unity-Technologies/Unity-Simulation-Docs/blob/master/doc/troubleshooting.md#macos-gatekeeper) for help.
+
 ### Login
 
 Use your Unity credentials to login via the CLI.

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -47,7 +47,7 @@ Unzip the quick start materials, `unity_simulation_bundle.zip`, to a well known 
 
 For example, if the quick start materials were downloaded and unzipped in the `Downloads` directory one of the following commands will change to the correct directory to execute the Unity Simulation CLI commands in the terminal window.
 
-OSX:
+macOS:
 
 ```console
 $ cd ~/Downloads/unity_simulation_bundle
@@ -63,10 +63,24 @@ Windows:
 
 Use your Unity credentials to login via the CLI.
 
-OSX:
+macOS:
 
 ```console
 $ USimCLI/mac/usim login auth
+```
+
+```console
+$ USimCLI/mac-legacy/usim login auth
+```
+
+Ubuntu:
+
+```console
+$ USimCLI/ubuntu18.04/usim login auth
+```
+
+```console
+$ USimCLI/ubuntu16.04/usim login auth
 ```
 
 Windows:
@@ -82,10 +96,24 @@ This will either ask you to enter your Unity credentials in a browser or if you 
 
 *NOTE*: In the event that your token expires you can run the following command to refresh your authentication.
 
-OSX:
+macOS:
 
 ```console
 $ USimCLI/mac/usim refresh auth
+```
+
+```console
+$ USimCLI/mac-legacy/usim refresh auth
+```
+
+Ubuntu:
+
+```console
+$ USimCLI/ubuntu18.04/usim refresh auth
+```
+
+```console
+$ USimCLI/ubuntu16.04/usim refresh auth
 ```
 
 Windows:
@@ -104,11 +132,26 @@ Prior to starting the run please ensure that you have a new or existing unity pr
 
 Back in the terminal run the following command to set the active Unity Project ID in Unity Simulation.
 
-OSX:
+macOS:
 
 ```console
 $ USimCLI/mac/usim activate project
 ```
+
+```console
+$ USimCLI/mac-legacy/usim activate project
+```
+
+Ubuntu:
+
+```console
+$ USimCLI/ubuntu18.04/usim activate project
+```
+
+```console
+$ USimCLI/ubuntu16.04/usim activate project
+```
+
 
 Windows:
 
@@ -148,7 +191,7 @@ Once a Unity Cloud Project ID has been activated you can begin uploading the nec
 
 All commands must be executed from the `unity_simulation_bundle` directory downloaded in the [Download](#download-unity-simulation-bundle-quick-start-materials) step of this guide and user must have at least one Unity cloud project described in the [Activate](#activate-unity-project) step.
 
-MacOS
+macOS 10.15 Catalina (replace `mac` with `mac-legacy` for 10.13 High Sierra and 10.14 Mojave)
 ```shell
 $ USimCLI/mac/usim login auth
 $ USimCLI/mac/usim activate project
@@ -172,6 +215,32 @@ $ USimCLI/mac/usim describe run-execution <exec-id>
 
 # After Simulation shows a 'Complete' status
 $ USimCLI/mac/usim download manifest <exec-id> --save-in=RunExecutionData
+```
+Ubuntu (replace `ubuntu18.04` with `ubuntu16.04` as needed)
+
+```shell
+$ USimCLI/ubuntu18.04/usim login auth
+$ USimCLI/ubuntu18.04/usim activate project
+
+$ USimCLI/ubuntu18.04/usim upload build ./RollaballLinuxBuild/rollaball_linux_build.zip
+    # Outputs  Build ID
+
+$ USimCLI/ubuntu18.04/usim upload app-param ./AppParams/app-param.json
+    #  Outputs AppParam ID
+
+$ USimCLI/ubuntu18.04/usim define run
+    # Outputs Run Definition ID
+
+# Replace <run-def-id> with the ID output by the previous command
+$ USimCLI/ubuntu18.04/usim execute run <run-def-id>
+    # Outputs Run Execution ID
+
+# Simulation Status
+$ USimCLI/ubuntu18.04/usim summarize run-execution <exec-id>
+$ USimCLI/ubuntu18.04/usim describe run-execution <exec-id>
+
+# After Simulation shows a 'Complete' status
+$ USimCLI/ubuntu18.04/usim download manifest <exec-id> --save-in=RunExecutionData
 ```
 
 Windows
@@ -205,7 +274,7 @@ Windows
 A zipped Linux build of the Unity tutorial scene [RollABall](https://learn.unity.com/project/roll-a-ball-tutorial) has been included with the quick start materials.
 The following commands will upload this zip to the Unity Simulation service so the scene can be executed on Unity Simulation.
 
-OSX:
+macOS:
 
 ```console
 $ USimCLI/mac/usim upload build RollaballLinuxBuild/rollaball_linux_build.zip
@@ -229,7 +298,7 @@ RollaballLinuxBuild/rollaball_linux_build.zip successfully uploaded with ID <bui
 
 Upload an Application Parameter file which contains values used to set variables during the execution of the RollABall simulation. For example, number of players and simulation run time are variables set from this file.
 
-OSX:
+macOS:
 
 ```console
 $ USimCLI/mac/usim upload app-param AppParams/app-param.json
@@ -255,7 +324,7 @@ The app-param that we provided will generate around 30 images in 30 seconds and 
 
 This step will launch you into a text-based wizard to define a simulation run. This definition will contain the build id, app-param id(s), system parameters to execute the build with, and number of instances the simulation should execute with each app-param.
 
-OSX:
+macOS:
 
 ```console
 $ USimCLI/mac/usim define run
@@ -318,7 +387,7 @@ Since we have only uploaded one app-param we will select the only app-param list
 
 *NOTE*: If the same app-param file is selected multiple times only the last defined number of instances will be used.
 
-OSX:
+macOS and Ubuntu:
 
 ```console
 Directory name where this run definition (my-new-simulation.json) will be saved: ./RunDefinitions/
@@ -334,7 +403,7 @@ Run definition saved as .\RunDefinitions\my-new-simulation.json
 
 Enter a valid directory to save the run definition as a JSON file on the local filesystem in the directory specified.
 
-OSX:
+macOS and Ubuntu:
 
 ```console
 Would you like to upload the run definition now? (Y/n) y
@@ -355,7 +424,7 @@ Finally there will be a prompt asking to upload the run-definition we just creat
 
 In the event that you did not upload the run definition in the previous step or you need to upload a run definition that already exist on the filesystem you can do so by entering the following command.
 
-OSX:
+macOS and Ubuntu:
 
 ```console
 $ USimCLI/mac/usim upload run RunDefinitions/my-new-simulation.json
@@ -380,10 +449,23 @@ In this step you will submit the run definition uploaded in the previous step to
 
 Replace <run-def-id> with the run ID returned in the previous step for the following commands.
 
-OSX:
+macOS:
 
 ```console
 $ USimCLI/mac/usim execute run <run-def-id>
+```
+
+```console
+$ USimCLI/mac-legacy/usim execute run <run-def-id>
+```
+
+Ubuntu:
+
+```console
+$ USimCLI/ubuntu18.04/usim execute run <run-def-id>
+```
+```console
+$ USimCLI/ubuntu16.04/usim execute run <run-def-id>
 ```
 
 Windows:
@@ -407,7 +489,7 @@ To periodically check on the run execution status the following two commands can
 
 #### Summarize Run Execution
 
-OSX:
+macOS and Ubuntu:
 
 ```console
 $ USimCLI/mac/usim summarize run-execution <exec-id>
@@ -443,7 +525,7 @@ Once you see counts greater than zero for an instance state in the summary table
 
 #### Describe Run Execution
 
-OSX:
+macOS and Ubuntu:
 
 ```console
 $ USimCLI/mac/usim describe run-execution <exec-id> --states=in-progress,failed
@@ -484,7 +566,7 @@ Data generated by the simulation will be available for download for 90 days. Aft
 
 This command will not actually download the data directly and instead it will download a manifest file in CSV format with signed URLs to the data that this run has produced; such as images and logs. You will need to provide the path to the directory where you want the CLI to save the manifest file. The signed URL's in the `download_url` column of the manifest file will only be valid for a limited time, after which you will need to generate a new manifest. You may specify the duration of this period by passing the --expires=<seconds> flag. The maximum duration is one week (604,800 seconds).
 
-OSX:
+macOS and Ubuntu:
 
 ```console
 $ USimCLI/mac/usim download manifest <exec-id> --save-in=RunExecutionData

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -63,3 +63,24 @@ usim get projects > my_projects.txt
 OR
 usim get projects | less
 ```
+
+## macOS Gatekeeper
+
+Apple has [information and instructions](https://support.apple.com/en-us/HT202491) for Gatekeeper issues.
+
+#### Validating checksums
+
+Our release notes will have checksums included for macOS releases. You can verify that the `usim` executable is in tact by comparing the checksum of the file. Produce a checksum with the `shasum -a 256 usim` command and compare the output with the checksum included in the release notes.
+
+#### Quarantine attribute
+
+macOS adds a quarantine attribute that may prevent launching usim. If this occurs you should first [validate the checksum](#Validating-checksums). You can remove the quarantine attribute with `xattr -rd com.apple.quarantine /path/to/usim`.
+
+#### Allow terminal to load libraries
+Error `not valid for use in process using Library Validation: library load disallowed by system policy`
+
+The macOS Terminal app settings may need to be set to allow loading libraries. Navigate to System Preferences and then:
+
+Security & privacy -> Privacy tab -> Developer tools -> make sure terminal checkbox is checked
+
+


### PR DESCRIPTION
0.8.2 cli release includes support for new platforms Ubuntu and macOS 15+

- Add troubleshooting steps for known-issues on macOS
- update quickstart with new cut-&-paste commands